### PR TITLE
fix: preserve `this` binding when rolling up unseen counts

### DIFF
--- a/app/utils/mailboxDisplay.ts
+++ b/app/utils/mailboxDisplay.ts
@@ -163,7 +163,7 @@ export class MailboxDisplayUtils {
             }
         }
 
-        roots.forEach(this.rollupUnseen);
+        roots.forEach((node) => this.rollupUnseen(node));
         return roots;
     }
 


### PR DESCRIPTION
Passing `this.rollupUnseen` as a bare reference to `Array.forEach` detached it from the class, so its recursive `this.rollupUnseen(child)` call threw "Cannot read properties of undefined". This crashed buildMailboxTree and prevented the sidebar folder tree from rendering.